### PR TITLE
Gridicons: Swift Mark 4 support

### DIFF
--- a/Gridicons/Gridicons/Gridicons.swift
+++ b/Gridicons/Gridicons/Gridicons.swift
@@ -192,6 +192,7 @@ public final class Gridicon: NSObject {
     }
     
     /// - returns: A template image of the specified Gridicon type, at the default size.
+    @objc
     public static func iconOfType(_ type: GridiconType) -> UIImage {
         return iconOfType(type, withSize: defaultSize)
     }
@@ -199,6 +200,7 @@ public final class Gridicon: NSObject {
     // These are two separate methods (rather than one method with a default argument) because Obj-C
     
     /// - returns: A template image of the specified Gridicon type, at the specified size.
+    @objc
     public static func iconOfType(_ type: GridiconType, withSize size: CGSize) -> UIImage {
         if let icon = cachedIconOfType(type, withSize: size) {
             return icon

--- a/GridiconsDemo/GridiconsDemo.xcodeproj/project.pbxproj
+++ b/GridiconsDemo/GridiconsDemo.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 				TargetAttributes = {
 					1704C20F1CAF0D7E00F991DE = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 0910;
 					};
 				};
 			};
@@ -293,7 +293,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.GridiconsDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -305,7 +305,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.GridiconsDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/GridiconsDemo/GridiconsDemo/ViewController.swift
+++ b/GridiconsDemo/GridiconsDemo/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
         return types
     }()
     
-    var iconSize = CGSize(width: 24.0, height: 24.0)
+    @objc var iconSize = CGSize(width: 24.0, height: 24.0)
     
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
### Details:
This (small!) PR adds Swift 4.0 support (by explicitly exposing the public methods to ObjC).

Needs Review: @frosty 
