### PR TITLE
Update the filter icon

### DIFF
--- a/Gridicons.podspec
+++ b/Gridicons.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Gridicons"
-  s.version      = "0.17"
+  s.version      = "0.18"
   s.summary      = "Gridicons is a tiny framework which generates Gridicon images at any resolution."
 
   s.homepage     = "http://apps.wordpress.com"

--- a/Gridicons.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Gridicons.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Gridicons/Gridicons/GridiconsGenerated.swift
+++ b/Gridicons/Gridicons/GridiconsGenerated.swift
@@ -8263,62 +8263,58 @@ class GridiconsGenerated: NSObject {
         context.restoreGState()
     }
     
-    class func drawGridiconsfilter(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 16, height: 17), resizing: ResizingBehavior = .aspectFit) {
+    class func drawGridiconsfilter(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 24, height: 24), resizing: ResizingBehavior = .aspectFit) {
         /// General Declarations
         let context = UIGraphicsGetCurrentContext()!
-        
+
         /// Resize to Target Frame
         context.saveGState()
-        let resizedFrame = resizing.apply(rect: CGRect(x: 0, y: 0, width: 16, height: 17), target: targetFrame)
+        let resizedFrame = resizing.apply(rect: CGRect(x: 0, y: 0, width: 24, height: 24), target: targetFrame)
         context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
-        context.scaleBy(x: resizedFrame.width / 16, y: resizedFrame.height / 17)
-        context.translateBy(x: -1171, y: -301)
-        
+        context.scaleBy(x: resizedFrame.width / 24, y: resizedFrame.height / 24)
+
         /// gridicons-filter
         do {
             context.saveGState()
-            context.translateBy(x: 1171, y: 301)
-            
-            /// filter
-            do {
-                context.saveGState()
-                
-                /// filter_1_
-                do {
-                    context.saveGState()
-                    
-                    /// Shape
-                    let shape = UIBezierPath()
-                    shape.move(to: CGPoint(x: 14.19, y: 0))
-                    shape.addLine(to: CGPoint(x: 1.01, y: 0))
-                    shape.addCurve(to: CGPoint(x: 0, y: 0.99), controlPoint1: CGPoint(x: 0.45, y: -0), controlPoint2: CGPoint(x: 0, y: 0.44))
-                    shape.addCurve(to: CGPoint(x: 0.3, y: 1.71), controlPoint1: CGPoint(x: -0, y: 1.26), controlPoint2: CGPoint(x: 0.11, y: 1.52))
-                    shape.addLine(to: CGPoint(x: 5.6, y: 7))
-                    shape.addLine(to: CGPoint(x: 5.6, y: 13))
-                    shape.addLine(to: CGPoint(x: 9.6, y: 17))
-                    shape.addLine(to: CGPoint(x: 9.6, y: 7))
-                    shape.addLine(to: CGPoint(x: 14.89, y: 1.71))
-                    shape.addCurve(to: CGPoint(x: 14.89, y: 0.3), controlPoint1: CGPoint(x: 15.28, y: 1.32), controlPoint2: CGPoint(x: 15.28, y: 0.69))
-                    shape.addCurve(to: CGPoint(x: 14.19, y: 0), controlPoint1: CGPoint(x: 14.71, y: 0.11), controlPoint2: CGPoint(x: 14.45, y: 0))
-                    shape.addLine(to: CGPoint(x: 14.19, y: 0))
-                    shape.close()
-                    shape.move(to: CGPoint(x: 14.19, y: 0))
-                    context.saveGState()
-                    context.translateBy(x: 0.41, y: -0)
-                    shape.usesEvenOddFillRule = true
-                    UIColor.black.setFill()
-                    shape.fill()
-                    context.restoreGState()
-                    
-                    context.restoreGState()
-                }
-                
-                context.restoreGState()
-            }
-            
+
+            /// Rectangle
+            let rectangle = UIBezierPath()
+            rectangle.move(to: CGPoint.zero)
+            rectangle.addLine(to: CGPoint(x: 24, y: 0))
+            rectangle.addLine(to: CGPoint(x: 24, y: 24))
+            rectangle.addLine(to: CGPoint(x: 0, y: 24))
+            rectangle.addLine(to: CGPoint.zero)
+            rectangle.close()
+
+            /// Shape
+            let shape = UIBezierPath()
+            shape.move(to: CGPoint(x: 7, y: 14))
+            shape.addLine(to: CGPoint(x: 11, y: 14))
+            shape.addLine(to: CGPoint(x: 11, y: 12))
+            shape.addLine(to: CGPoint(x: 7, y: 12))
+            shape.addLine(to: CGPoint(x: 7, y: 14))
+            shape.close()
+            shape.move(to: CGPoint(x: 3, y: 8))
+            shape.addLine(to: CGPoint(x: 15, y: 8))
+            shape.addLine(to: CGPoint(x: 15, y: 6))
+            shape.addLine(to: CGPoint(x: 3, y: 6))
+            shape.addLine(to: CGPoint(x: 3, y: 8))
+            shape.close()
+            shape.move(to: CGPoint.zero)
+            shape.addLine(to: CGPoint(x: 0, y: 2))
+            shape.addLine(to: CGPoint(x: 18, y: 2))
+            shape.addLine(to: CGPoint(x: 18, y: 0))
+            shape.addLine(to: CGPoint.zero)
+            shape.close()
+            context.saveGState()
+            context.translateBy(x: 3, y: 5)
+            UIColor.black.setFill()
+            shape.fill()
+            context.restoreGState()
+
             context.restoreGState()
         }
-        
+
         context.restoreGState()
     }
     

--- a/Gridicons/Gridicons/Info.plist
+++ b/Gridicons/Gridicons/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.17</string>
+	<string>0.18</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
In this PR, the filter icon changes from a funnel to a 3-line symbol. The filter icon was updated here: https://github.com/Automattic/gridicons/pull/295. Testing instructions included for whichever host app you prefer. Testing on both apps is not required.

cc: @bummytime 

![44091089-3d8796c4-9fc4-11e8-8ed4-582cf8d31ea7](https://user-images.githubusercontent.com/1062444/51146031-39896500-181b-11e9-96d9-15e8b633c2a8.png)

## To test, using WCiOS
1. Check out this WCiOS PR: https://github.com/woocommerce/woocommerce-ios/pull/609. 
2. Navigate to the Orders tab.
3. Look at the nav bar's top right button.
4. Verify the filter icon looks like the one listed above, on the right.  

## To test, using WPiOS
1. Add the `.filter` icon to a known gridicon UI.
2. Point the podfile to `pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'feature/filter-icon-update'`
3. `pod update Gridicons`
4. Run the app and verify the icon looks like 3 lines.