### PR TITLE
Add gift icon

### DIFF
--- a/Gridicons.podspec
+++ b/Gridicons.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Gridicons"
-  s.version      = "0.18"
+  s.version      = "0.19"
   s.summary      = "Gridicons is a tiny framework which generates Gridicon images at any resolution."
 
   s.homepage     = "http://apps.wordpress.com"

--- a/Gridicons/Gridicons/Gridicons.swift
+++ b/Gridicons/Gridicons/Gridicons.swift
@@ -116,6 +116,7 @@ public enum GridiconType: Int {
     case heading
     case grid
     case globe
+    case gift
     case fullscreenExit
     case fullscreen
     case folderMultiple
@@ -450,6 +451,8 @@ public final class Gridicon: NSObject {
             return GridiconsGenerated.imageOfGridiconsgrid(size: size)
         case .globe:
             return GridiconsGenerated.imageOfGridiconsglobe(size: size)
+        case .gift:
+            return GridiconsGenerated.imageOfGridiconsgift(size: size)
         case .fullscreen:
             return GridiconsGenerated.imageOfGridiconsfullscreen(size: size)
         case .fullscreenExit:

--- a/Gridicons/Gridicons/GridiconsGenerated.swift
+++ b/Gridicons/Gridicons/GridiconsGenerated.swift
@@ -12480,27 +12480,10 @@ class GridiconsGenerated: NSObject {
             shape.addLine(to: CGPoint(x: 11, y: 11))
             shape.close()
 
-            /// Shape (Outline Mask)
             context.saveGState()
-            shape.addClip()
-
-            /// Rectangle
-            let rectangle = UIBezierPath()
-            rectangle.move(to: CGPoint.zero)
-            rectangle.addLine(to: CGPoint(x: 24, y: 0))
-            rectangle.addLine(to: CGPoint(x: 24, y: 24))
-            rectangle.addLine(to: CGPoint(x: 0, y: 24))
-            rectangle.addLine(to: CGPoint.zero)
-            rectangle.close()
-            context.saveGState()
-            context.translateBy(x: -2, y: -1)
-            UIColor(hue: 0.583, saturation: 0.09, brightness: 0.698, alpha: 1).setFill()
-            rectangle.fill()
-            context.restoreGState()
-
-            context.restoreGState()
-            // End Shape (Outline Mask)
-
+            shape.usesEvenOddFillRule = true
+            UIColor.black.setFill()
+            shape.fill()
             context.restoreGState()
         }
 

--- a/Gridicons/Gridicons/GridiconsGenerated.swift
+++ b/Gridicons/Gridicons/GridiconsGenerated.swift
@@ -12405,6 +12405,107 @@ class GridiconsGenerated: NSObject {
         
         context.restoreGState()
     }
+
+    class func drawGridiconsgift(frame targetFrame: CGRect = CGRect(x: 0, y: 0, width: 20, height: 21), resizing: ResizingBehavior = .aspectFit) {
+        /// General Declarations
+        let context = UIGraphicsGetCurrentContext()!
+
+        /// Resize to Target Frame
+        context.saveGState()
+        let resizedFrame = resizing.apply(rect: CGRect(x: 0, y: 0, width: 20, height: 21), target: targetFrame)
+        context.translateBy(x: resizedFrame.minX, y: resizedFrame.minY)
+        context.scaleBy(x: resizedFrame.width / 20, y: resizedFrame.height / 21)
+        context.translateBy(x: -178, y: -323)
+
+        /// gridicons-gift
+        do {
+            context.saveGState()
+            context.translateBy(x: 178, y: 323)
+
+            /// Shape
+            let shape = UIBezierPath()
+            shape.move(to: CGPoint(x: 20, y: 5))
+            shape.addLine(to: CGPoint(x: 15.2, y: 5))
+            shape.addCurve(to: CGPoint(x: 16, y: 3), controlPoint1: CGPoint(x: 15.7, y: 4.5), controlPoint2: CGPoint(x: 16, y: 3.8))
+            shape.addCurve(to: CGPoint(x: 13, y: 0), controlPoint1: CGPoint(x: 16, y: 1.3), controlPoint2: CGPoint(x: 14.7, y: 0))
+            shape.addCurve(to: CGPoint(x: 10, y: 3), controlPoint1: CGPoint(x: 11.3, y: 0), controlPoint2: CGPoint(x: 10, y: 1.3))
+            shape.addCurve(to: CGPoint(x: 7, y: 0), controlPoint1: CGPoint(x: 10, y: 1.3), controlPoint2: CGPoint(x: 8.7, y: 0))
+            shape.addCurve(to: CGPoint(x: 4, y: 3), controlPoint1: CGPoint(x: 5.3, y: 0), controlPoint2: CGPoint(x: 4, y: 1.3))
+            shape.addCurve(to: CGPoint(x: 4.8, y: 5), controlPoint1: CGPoint(x: 4, y: 3.8), controlPoint2: CGPoint(x: 4.3, y: 4.5))
+            shape.addLine(to: CGPoint(x: 0, y: 5))
+            shape.addLine(to: CGPoint(x: 0, y: 11))
+            shape.addLine(to: CGPoint(x: 1, y: 11))
+            shape.addLine(to: CGPoint(x: 1, y: 19))
+            shape.addCurve(to: CGPoint(x: 3, y: 21), controlPoint1: CGPoint(x: 1, y: 20.1), controlPoint2: CGPoint(x: 1.9, y: 21))
+            shape.addLine(to: CGPoint(x: 17, y: 21))
+            shape.addCurve(to: CGPoint(x: 19, y: 19), controlPoint1: CGPoint(x: 18.1, y: 21), controlPoint2: CGPoint(x: 19, y: 20.1))
+            shape.addLine(to: CGPoint(x: 19, y: 11))
+            shape.addLine(to: CGPoint(x: 20, y: 11))
+            shape.addLine(to: CGPoint(x: 20, y: 5))
+            shape.close()
+            shape.move(to: CGPoint(x: 18, y: 9))
+            shape.addLine(to: CGPoint(x: 11, y: 9))
+            shape.addLine(to: CGPoint(x: 11, y: 7))
+            shape.addLine(to: CGPoint(x: 18, y: 7))
+            shape.addLine(to: CGPoint(x: 18, y: 9))
+            shape.close()
+            shape.move(to: CGPoint(x: 14, y: 3))
+            shape.addCurve(to: CGPoint(x: 13, y: 2), controlPoint1: CGPoint(x: 14, y: 2.4), controlPoint2: CGPoint(x: 13.6, y: 2))
+            shape.addCurve(to: CGPoint(x: 12, y: 3), controlPoint1: CGPoint(x: 12.4, y: 2), controlPoint2: CGPoint(x: 12, y: 2.4))
+            shape.addCurve(to: CGPoint(x: 13, y: 4), controlPoint1: CGPoint(x: 12, y: 3.6), controlPoint2: CGPoint(x: 12.4, y: 4))
+            shape.addCurve(to: CGPoint(x: 14, y: 3), controlPoint1: CGPoint(x: 13.6, y: 4), controlPoint2: CGPoint(x: 14, y: 3.6))
+            shape.close()
+            shape.move(to: CGPoint(x: 7, y: 2))
+            shape.addCurve(to: CGPoint(x: 8, y: 3), controlPoint1: CGPoint(x: 7.6, y: 2), controlPoint2: CGPoint(x: 8, y: 2.4))
+            shape.addCurve(to: CGPoint(x: 7, y: 4), controlPoint1: CGPoint(x: 8, y: 3.6), controlPoint2: CGPoint(x: 7.6, y: 4))
+            shape.addCurve(to: CGPoint(x: 6, y: 3), controlPoint1: CGPoint(x: 6.4, y: 4), controlPoint2: CGPoint(x: 6, y: 3.6))
+            shape.addCurve(to: CGPoint(x: 7, y: 2), controlPoint1: CGPoint(x: 6, y: 2.4), controlPoint2: CGPoint(x: 6.4, y: 2))
+            shape.close()
+            shape.move(to: CGPoint(x: 9, y: 7))
+            shape.addLine(to: CGPoint(x: 2, y: 7))
+            shape.addLine(to: CGPoint(x: 2, y: 9))
+            shape.addLine(to: CGPoint(x: 9, y: 9))
+            shape.addLine(to: CGPoint(x: 9, y: 7))
+            shape.close()
+            shape.move(to: CGPoint(x: 9, y: 11))
+            shape.addLine(to: CGPoint(x: 9, y: 19))
+            shape.addLine(to: CGPoint(x: 3, y: 19))
+            shape.addLine(to: CGPoint(x: 3, y: 11))
+            shape.addLine(to: CGPoint(x: 9, y: 11))
+            shape.close()
+            shape.move(to: CGPoint(x: 11, y: 11))
+            shape.addLine(to: CGPoint(x: 11, y: 19))
+            shape.addLine(to: CGPoint(x: 17, y: 19))
+            shape.addLine(to: CGPoint(x: 17, y: 11))
+            shape.addLine(to: CGPoint(x: 11, y: 11))
+            shape.close()
+
+            /// Shape (Outline Mask)
+            context.saveGState()
+            shape.addClip()
+
+            /// Rectangle
+            let rectangle = UIBezierPath()
+            rectangle.move(to: CGPoint.zero)
+            rectangle.addLine(to: CGPoint(x: 24, y: 0))
+            rectangle.addLine(to: CGPoint(x: 24, y: 24))
+            rectangle.addLine(to: CGPoint(x: 0, y: 24))
+            rectangle.addLine(to: CGPoint.zero)
+            rectangle.close()
+            context.saveGState()
+            context.translateBy(x: -2, y: -1)
+            UIColor(hue: 0.583, saturation: 0.09, brightness: 0.698, alpha: 1).setFill()
+            rectangle.fill()
+            context.restoreGState()
+
+            context.restoreGState()
+            // End Shape (Outline Mask)
+
+            context.restoreGState()
+        }
+
+        context.restoreGState()
+    }
     
     
     //MARK: - Canvas Images
@@ -14421,6 +14522,17 @@ class GridiconsGenerated: NSObject {
         image = UIGraphicsGetImageFromCurrentImageContext()!
         UIGraphicsEndImageContext()
         
+        return image
+    }
+
+    class func imageOfGridiconsgift(size: CGSize) -> UIImage {
+        var image: UIImage
+
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        GridiconsGenerated.drawGridiconsgift(frame: CGRect(origin: CGPoint.zero, size: size))
+        image = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+
         return image
     }
     

--- a/Gridicons/Gridicons/Info.plist
+++ b/Gridicons/Gridicons/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.18</string>
+	<string>0.19</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Gift icon used in https://github.com/woocommerce/woocommerce-ios/issues/1232

## Changes
- Added `gift` icon
  - The generated code from Paintcode plugin had shape filling issues like in the screenshot below. I checked how other icons with hollow shapes clipped inside (like `customposttype`) and fixed in https://github.com/Automattic/Gridicons-iOS/commit/6e7136a1a009e15a50ef134eb0f558f80a2fc840
<img width="297" alt="Screen Shot 2019-08-30 at 10 46 34 AM" src="https://user-images.githubusercontent.com/1945542/63996717-020fc480-cb2f-11e9-921e-cdfdb8ada738.png">

## Testing
- Build and run the demo app (`GridiconsDemo`)
- Scroll to the gift icon (near the globe icon) a bit after the middle
- Zoom in and out with the control at the bottom --> the gift icon should look like below

![Simulator Screen Shot - iPhone 5s - 2019-08-30 at 13 58 11](https://user-images.githubusercontent.com/1945542/63996800-47cc8d00-cb2f-11e9-9538-b4b3d019ed1b.png)

