### PR TITLE
1.0 Release and API update

### DIFF
--- a/Gridicons.podspec
+++ b/Gridicons.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Gridicons"
-  s.version      = "0.20-beta.2"
+  s.version      = "1.0-beta.1"
   s.summary      = "Gridicons is a tiny framework which generates Gridicon images at any resolution."
 
   s.homepage     = "http://apps.wordpress.com"

--- a/Gridicons/Gridicons.xcodeproj/project.pbxproj
+++ b/Gridicons/Gridicons.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.Gridicons;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -384,6 +385,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.Gridicons;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Gridicons/Gridicons/Gridicons.swift
+++ b/Gridicons/Gridicons/Gridicons.swift
@@ -1,6 +1,33 @@
 import Foundation
 
-public final class Gridicon: NSObject {
+public extension UIImage {
+
+    /// - returns: A template image of the specified Gridicon type, at the default size.
+    ///
+    @objc(gridiconOfType:)
+    static func gridicon(_ type: GridiconType) -> UIImage {
+        return gridicon(type, size: Gridicon.defaultSize)
+    }
+
+    // These are two separate methods (rather than one method with a default argument) because Obj-C
+    //
+    @objc(gridiconOfType:withSize:)
+    static func gridicon(_ type: GridiconType, size: CGSize) -> UIImage {
+        if let icon = Gridicon.cachedIcon(type: type, with: size) {
+            return icon
+        }
+
+        let icon = Gridicon.generateIcon(type: type, with: size).withRenderingMode(.alwaysTemplate)
+        Gridicon.cache.setObject(icon, forKey: "\(type.rawValue)-\(size.width)-\(size.height)" as AnyObject)
+
+        return icon
+    }
+}
+
+/// The Gridicon class encapsulates generation and caching of Gridicon icons, however requesting
+/// of images should be done via the UIImage extensions `gridicon(_:)` and `gridicon(_:size:)`.
+///
+public class Gridicon: NSObject {
     public static let defaultSize = CGSize(width: 24.0, height: 24.0)
 
     fileprivate static let cache = NSCache<AnyObject, AnyObject>()
@@ -11,37 +38,30 @@ public final class Gridicon: NSObject {
         cache.removeAllObjects()
     }
 
-    /// - returns: A template image of the specified Gridicon type, at the default size.
-    ///
-    @objc
-    public static func iconOfType(_ type: GridiconType) -> UIImage {
-        return iconOfType(type, withSize: defaultSize)
-    }
-
-    // These are two separate methods (rather than one method with a default argument) because Obj-C
-
-    /// - returns: A template image of the specified Gridicon type, at the specified size.
-    @objc
-    public static func iconOfType(_ type: GridiconType, withSize size: CGSize) -> UIImage {
-        if let icon = cachedIconOfType(type, withSize: size) {
-            return icon
-        }
-
-        let icon = generateIconOfType(type, withSize: size).withRenderingMode(.alwaysTemplate)
-        cache.setObject(icon, forKey: "\(type.rawValue)-\(size.width)-\(size.height)" as AnyObject)
-
-        return icon
-    }
-
-    fileprivate static func cachedIconOfType(_ type: GridiconType, withSize size: CGSize) -> UIImage? {
+    fileprivate static func cachedIcon(type: GridiconType, with size: CGSize) -> UIImage? {
         return cache.object(forKey: "\(type.rawValue)-\(size.width)-\(size.height)" as AnyObject) as? UIImage
     }
 
-    fileprivate static func generateIconOfType(_ type: GridiconType, withSize size: CGSize) -> UIImage {
+    fileprivate static func generateIcon(type: GridiconType, with size: CGSize) -> UIImage {
         let renderer = UIGraphicsImageRenderer(size: size)
         let image = renderer.image { _ in
             type.icon.draw(in: CGRect(origin: .zero, size: size))
         }
         return image
+    }
+
+    // MARK: - Deprecated
+
+    /// - returns: A template image of the specified Gridicon type, at the default size.
+    ///
+    @available(*, deprecated, message: "Use UIImage.gridicon(_:) instead.")
+    public static func iconOfType(_ type: GridiconType) -> UIImage {
+        return .gridicon(type)
+    }
+
+    /// - returns: A template image of the specified Gridicon type, at the specified size.
+    @available(*, deprecated, message: "Use UIImage.gridicon(_:size:) instead.")
+    public static func iconOfType(_ type: GridiconType, withSize size: CGSize) -> UIImage {
+        return .gridicon(type, size: size)
     }
 }

--- a/Gridicons/Gridicons/Info.plist
+++ b/Gridicons/Gridicons/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.19</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Gridicons/GridiconsTests/GridiconsTests.swift
+++ b/Gridicons/GridiconsTests/GridiconsTests.swift
@@ -17,29 +17,29 @@ class GridiconsTests: XCTestCase {
     }
     
     func testIconsAreCached() {
-        let icon = Gridicon.iconOfType(.addImage)
-        let icon2 = Gridicon.iconOfType(.addImage)
+        let icon: UIImage = .gridicon(.addImage)
+        let icon2: UIImage = .gridicon(.addImage)
         
         XCTAssertEqual(icon, icon2)
         
         Gridicon.clearCache()
-        let icon3 = Gridicon.iconOfType(.addImage)
+        let icon3: UIImage = .gridicon(.addImage)
         
         XCTAssertNotEqual(icon2, icon3)
     }
     
     func testIconsAreTheCorrectSize() {
-        let icon = Gridicon.iconOfType(.domains)
+        let icon: UIImage = .gridicon(.domains)
         XCTAssertEqual(icon.size, Gridicon.defaultSize)
         
         let size = CGSize(width: 250, height: 250)
-        let icon2 = Gridicon.iconOfType(.userCircle, withSize: size)
+        let icon2: UIImage = .gridicon(.userCircle, size: size)
         XCTAssertEqual(icon2.size, size)
     }
     
     func testSingleIconGenerationPerformance() {
         self.measure {
-            let _ = Gridicon.iconOfType(.pages)
+            let _ = UIImage.gridicon(.pages)
         }
     }
     
@@ -54,7 +54,7 @@ class GridiconsTests: XCTestCase {
         }()
         
         self.measure {
-            let _ = iconTypes.map { Gridicon.iconOfType($0) }
+            let _ = iconTypes.map { UIImage.gridicon($0) }
         }
     }
 
@@ -65,6 +65,6 @@ class GridiconsTests: XCTestCase {
         }
 
         // An error will be thrown if instantiating an icon fails
-        iconTypes.forEach({ let _ = Gridicon.iconOfType($0) })
+        iconTypes.forEach({ let _ = UIImage.gridicon($0) })
     }
 }

--- a/GridiconsDemo/GridiconsDemo/ViewController.swift
+++ b/GridiconsDemo/GridiconsDemo/ViewController.swift
@@ -69,7 +69,7 @@ extension ViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ImageCell", for: indexPath) as! ImageCell
         
-        cell.imageView.image = Gridicon.iconOfType(iconTypes[indexPath.row], withSize: iconSize)
+        cell.imageView.image = .gridicon(iconTypes[indexPath.row], size: iconSize)
         
         return cell
     }

--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ First, import the framework:
 
 Getting a `UIImage` of a Gridicon is as simple as:
 
-`let icon = Gridicon.iconOfType(.pages)`
+`let icon = UIImage.gridicon(.pages)`
+
+With type inference, this can be shortened further:
+
+`icon = .gridicon(.pages)`
 
 You can optionally specify a size (default is 24 x 24):
 
-`let icon = Gridicon.iconOfType(.pages, withSize: CGSize(width: 100, height: 100))`
+`let icon = UIImage.gridicon(.pages, size: CGSize(width: 100, height: 100))`
 
 The images that the framework produces use the `AlwaysTemplate` rendering mode, so you can tint them however you like.
 


### PR DESCRIPTION
This PR updates Gridicons to a 1.0 release number, and updates the API:

Getting an image of a Gridicon is now a case of doing:

`let icon = UIImage.gridicon(.pages)`

With type inference, this can be shortened further:

`icon = .gridicon(.pages)`

You can still optionally specify a size:

`let icon = UIImage.gridicon(.pages, size: CGSize(width: 100, height: 100))`

**To test**

* Build and run the demo app and ensure the icons still appear
* Check that tests still pass

You can also run and verify the associated [WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/13682) (link coming shortly).