### PR TITLE
Fix import of `xcassets` to resources bundles in `podspec`

### DIFF
--- a/Gridicons.podspec
+++ b/Gridicons.podspec
@@ -25,4 +25,5 @@ Pod::Spec.new do |s|
       'Gridicons/Gridicons/*.{xcassets}'
     ]
   }
+  s.resources = 'Gridicons/Gridicons/*.{xcassets}'
 end

--- a/Gridicons.podspec
+++ b/Gridicons.podspec
@@ -21,9 +21,9 @@ Pod::Spec.new do |s|
   s.source        = { git: 'https://github.com/Automattic/Gridicons-iOS.git', tag: s.version.to_s }
   s.source_files  = 'Gridicons/Gridicons/**/*.swift'
   s.resource_bundles = {
-    Gridicons: [
+    GridiconsAssets: [
       'Gridicons/Gridicons/*.{xcassets}'
     ]
   }
-  s.resources = 'Gridicons/Gridicons/*.{xcassets}'
+  #s.resources = 'Gridicons/Gridicons/*.{xcassets}'
 end

--- a/Gridicons.podspec
+++ b/Gridicons.podspec
@@ -25,5 +25,4 @@ Pod::Spec.new do |s|
       'Gridicons/Gridicons/*.{xcassets}'
     ]
   }
-  #s.resources = 'Gridicons/Gridicons/*.{xcassets}'
 end

--- a/Gridicons.podspec
+++ b/Gridicons.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Gridicons'
-  s.version       = '1.1.0'
+  s.version       = '1.2.0'
 
   s.summary       = 'Gridicons is a tiny framework which generates Gridicon images at any resolution.'
   s.description   = <<-DESC

--- a/Gridicons.stencil
+++ b/Gridicons.stencil
@@ -35,7 +35,7 @@ extension {{enumName}} {
   var icon: UIImage {
     var bundle = Bundle(for: BundleToken.self)
 
-    if let url = bundle.url(forResource: "Gridicons", withExtension: "bundle"),
+    if let url = bundle.url(forResource: "GridiconsAssets", withExtension: "bundle"),
         let assetBundle = Bundle(url: url) {
         // When loaded through CocoaPods, assets reside in a separate resource bundle
         bundle = assetBundle

--- a/Gridicons/Gridicons/GridiconsGenerated.swift
+++ b/Gridicons/Gridicons/GridiconsGenerated.swift
@@ -412,7 +412,7 @@ extension GridiconType {
   var icon: UIImage {
     var bundle = Bundle(for: BundleToken.self)
 
-    if let url = bundle.url(forResource: "Gridicons", withExtension: "bundle"),
+    if let url = bundle.url(forResource: "GridiconsAssets", withExtension: "bundle"),
         let assetBundle = Bundle(url: url) {
         // When loaded through CocoaPods, assets reside in a separate resource bundle
         bundle = assetBundle


### PR DESCRIPTION
In WCiOS during the last two years, we encountered a crash, that was happening during the first launch of the app on a new device (a new device, is that device that has never installed the application before). In particular, we encountered this crash https://github.com/woocommerce/woocommerce-ios/issues/2454 that can be easily reproducible following these steps:

1. Launch the simulator where you want to run the app.
2. Go on the `Device` menu, and click `Erase All content and settings...`.
3. Run WCiOS on that simulator.
4. Try to log in, adding your credentials.
5. After adding your email, you will encounter a crash on the Gridicons library.

After several investigations, it appears that the problem is caused by the way we import `xcassets` resources into the podspec file of Gridicons.

Basically, before we were integrating the `xcassets` like this
```
s.resource_bundles = {
    Gridicons: [
      'Gridicons/Gridicons/*.{xcassets}'
    ]
  }
```

using as bundle name `Gridicons` which create a conflict at runtime. For solving this issue, I modified the bundle for the resources to `GridiconsAssets` like this:

```
s.resource_bundles = {
    GridiconsAssets: [
      'Gridicons/Gridicons/*.{xcassets}'
    ]
  }
```

plus I edited the code where we use the old bundle name. The reason for this conflict is well explained in this [post](https://blog.katastros.com/a?ID=00850-b692d1eb-485b-45b3-86c0-8b22f01cf5e8).
After importing this branch in WCiOS, the issue was fixed and I'm no more able to reproduce the crash 🚀 


