### PR TITLE
Add SwiftUI Image support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _None._
 ### New Features
 
 * Add Swift Package Manager support. [#71]
+* Add SwiftUI Image support. [#82]
 
 ### Bug Fixes
 

--- a/Gridicons.podspec
+++ b/Gridicons.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'Gridicons'
-  s.version       = '1.2.0'
+  s.version       = '1.3.0-beta.1'
 
   s.summary       = 'Gridicons is a tiny framework which generates Gridicon images at any resolution.'
   s.description   = <<-DESC

--- a/Gridicons.stencil
+++ b/Gridicons.stencil
@@ -1,4 +1,5 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
+import SwiftUI
 import UIKit
 
 {% if catalogs %}
@@ -35,6 +36,19 @@ extension {{enumName}} {
   }
 
   var icon: UIImage {
+    let image = UIImage(named: name, in: bundle(), compatibleWith: nil)
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+
+  @available(iOS 13.0, *)
+  var image: Image {
+    Image(name, bundle: bundle())
+  }
+}
+
+private extension GridiconType {
+  func bundle() -> Bundle {
 #if SWIFT_PACKAGE
     let bundle = Bundle.module
 #else
@@ -46,10 +60,7 @@ extension {{enumName}} {
         bundle = assetBundle
     }
 #endif
-
-    let image = UIImage(named: name, in: bundle, compatibleWith: nil)
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
+    return bundle
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ You can optionally specify a size (default is 24 x 24):
 
 The images that the framework produces use the `AlwaysTemplate` rendering mode, so you can tint them however you like.
 
+## SwiftUI Usage
+
+For SwiftUI projects (iOS 13.0+), you can use the `Image` type directly:
+
+```swift
+import SwiftUI
+import Gridicons
+
+struct ContentView: View {
+    var body: some View {
+        Image.gridicon(.pages)
+            .foregroundStyle(.orange) // Tints the icon
+    }
+}
+```
+
+The SwiftUI `Image` type also supports the template rendering mode, so you can tint it using the `foregroundStyle` modifier.
+
 ## Adding new icons
 
 To add new icons as they're added to the [Gridicons icon set](https://github.com/automattic/gridicons), complete the following steps:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ struct ContentView: View {
 
 The SwiftUI `Image` type also supports the template rendering mode, so you can tint it using the `foregroundStyle` modifier.
 
+## Development
+
+For code changes in `GridiconsGenerated.swift`:
+
+* Edit the `Gridicons.stencil` file to modify the template
+* If you haven't already, run `rake dependencies` to install SwiftGen
+* Run `rake gen` to regenerate the `GridiconsGenerated.swift` file
+
 ## Adding new icons
 
 To add new icons as they're added to the [Gridicons icon set](https://github.com/automattic/gridicons), complete the following steps:

--- a/Sources/Gridicons/Gridicons.swift
+++ b/Sources/Gridicons/Gridicons.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import UIKit
 
 public extension UIImage {
@@ -22,6 +23,15 @@ public extension UIImage {
         Gridicon.cache.setObject(icon, forKey: "\(type.rawValue)-\(size.width)-\(size.height)" as AnyObject)
 
         return icon
+    }
+}
+
+@available(iOS 13.0, *)
+public extension Image {
+    /// - returns: A SwiftUI image of the specified Gridicon type.
+    ///
+    static func gridicon(_ type: GridiconType) -> Image {
+        return type.image
     }
 }
 

--- a/Sources/Gridicons/GridiconsGenerated.swift
+++ b/Sources/Gridicons/GridiconsGenerated.swift
@@ -1,4 +1,5 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
+import SwiftUI
 import UIKit
 
 
@@ -412,6 +413,19 @@ extension GridiconType {
   }
 
   var icon: UIImage {
+    let image = UIImage(named: name, in: bundle(), compatibleWith: nil)
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+
+  @available(iOS 13.0, *)
+  var image: Image {
+      Image(name, bundle: bundle())
+  }
+}
+
+private extension GridiconType {
+  func bundle() -> Bundle {
 #if SWIFT_PACKAGE
     let bundle = Bundle.module
 #else
@@ -423,10 +437,7 @@ extension GridiconType {
         bundle = assetBundle
     }
 #endif
-
-    let image = UIImage(named: name, in: bundle, compatibleWith: nil)
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
+    return bundle
   }
 }
 

--- a/Sources/Gridicons/GridiconsGenerated.swift
+++ b/Sources/Gridicons/GridiconsGenerated.swift
@@ -420,7 +420,7 @@ extension GridiconType {
 
   @available(iOS 13.0, *)
   var image: Image {
-      Image(name, bundle: bundle())
+    Image(name, bundle: bundle())
   }
 }
 


### PR DESCRIPTION
This pull request introduces SwiftUI support for the `Gridicons` framework, updates the version to `1.3.0-beta.1`, and includes documentation changes to reflect these updates.

### Why

Before this PR, the Gridicons can only be used in UIKit as UIImage and using a `UIImage` in SwiftUI could lose resolution and appear blurry. I treid accessing the image assets in the asset catalog, but likely due to how the asset catalog is included in Cocoapods, it failed to locate the asset catalog in the Gridicons bundle in WCiOS.

### How

Added SwiftUI `Image` support, allowing the use of `Gridicons` directly in SwiftUI projects (iOS 13.0+). This includes a new `Image.gridicon(_:)` method for generating SwiftUI images from `GridiconType`.

### Testing steps

Please check out the WCiOS PR testing steps in https://github.com/woocommerce/woocommerce-ios/pull/15659.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
