### PR TITLE
AINFRA-283 - Set `queue: mac` explicitly in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,12 @@
-# Nodes with values to reuse in the pipeline.
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+env:
+  IMAGE_ID: xcode-15.0.1
+
 common_params:
   plugins: &common_plugins
     - automattic/a8c-ci-toolkit#2.15.0
-  # Common environment values to use with the `env` key.
-  env: &common_env
-    IMAGE_ID: xcode-15.0.1
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -14,7 +16,6 @@ steps:
   - label: "🔬 Validating Swift Package"
     key: "test"
     command: ".buildkite/validate_swift_package"
-    env: *common_env
     plugins: *common_plugins
 
   #################
@@ -23,7 +24,6 @@ steps:
   - label: "🔬 Validating Podspec"
     key: "validate"
     command: "validate_podspec"
-    env: *common_env
     plugins: *common_plugins
 
   #################
@@ -32,7 +32,6 @@ steps:
   - label: "🧹 Lint"
     key: "lint"
     command: "lint_pod"
-    env: *common_env
     plugins: *common_plugins
 
   #################
@@ -41,7 +40,6 @@ steps:
   - label: "⬆️ Publish Podspec"
     key: "publish"
     command: .buildkite/publish-pod.sh
-    env: *common_env
     plugins: *common_plugins
     depends_on:
       - "test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+agents:
+  queue: mac
+
 env:
   IMAGE_ID: xcode-16.4
 
@@ -46,5 +49,3 @@ steps:
       - "validate"
       - "lint"
     if: build.tag != null
-    agents:
-      queue: "mac"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 ---
 
 env:
-  IMAGE_ID: xcode-15.0.1
+  IMAGE_ID: xcode-16.4
 
 common_params:
   plugins: &common_plugins


### PR DESCRIPTION
This will allow adopting an improved default pipeline upload step on the CI infrastructure side of the setup. It also makes it clear what queue is in use just by looking at the pipeline file.

Notice it does not introduce the standard `shared-pipeline-vars` file because to use that we first need the default pipeline upload step in the IaC configuration.

See https://linear.app/a8c/issue/AINFRA-283